### PR TITLE
Revert "power: quickwakeup: initial driver" - not fully implemented yet

### DIFF
--- a/kernel/power/Kconfig
+++ b/kernel/power/Kconfig
@@ -343,11 +343,3 @@ config SUSPEND_TIME
 config POWERSUSPEND
 	bool "Powersuspend driver"
 	depends on SUSPEND
-
-config QUICK_WAKEUP
-	bool "Quick wakeup"
-	depends on SUSPEND
-	default y
-	---help---
-	  Allow kernel driver to do periodic jobs without resuming the full system
-	  This option can increase battery life on android powered smartphone.

--- a/kernel/power/Makefile
+++ b/kernel/power/Makefile
@@ -17,6 +17,5 @@ obj-$(CONFIG_CONSOLE_EARLYSUSPEND)	+= consoleearlysuspend.o
 obj-$(CONFIG_FB_EARLYSUSPEND)	+= fbearlysuspend.o
 obj-$(CONFIG_SUSPEND_TIME)	+= suspend_time.o
 
-obj-$(CONFIG_QUICK_WAKEUP)	+= quickwakeup.o
 obj-$(CONFIG_MAGIC_SYSRQ)	+= poweroff.o
 obj-$(CONFIG_POWERSUSPEND)	+= powersuspend.o


### PR DESCRIPTION
This reverts commit c3a53b6a8c00b18c7fdc734e2a9b58698c5d56c9.